### PR TITLE
Fix TUNNEL_ID template variable

### DIFF
--- a/cloudflared-config.template.yml
+++ b/cloudflared-config.template.yml
@@ -3,7 +3,7 @@
 # - n8n.{{DOMAIN}} -> Main UI
 # - webhook.{{DOMAIN}} -> Webhook endpoints
 
-tunnel: { { TUNNEL_ID } }
+tunnel: {{TUNNEL_ID}}
 credentials-file: /etc/cloudflared/creds/credentials.json
 
 ingress:


### PR DESCRIPTION
Fix TUNNEL_ID template variable for use with setup cloudflare tunnel script.

Resolves Issue #2 

Test shows TUNNEL_ID properly replaced in generated yml.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected tunnel configuration template formatting for improved syntax consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->