### PR TITLE
Fix option given to cloudflared tunnel list

### DIFF
--- a/setup-cloudflare-tunnel.sh
+++ b/setup-cloudflare-tunnel.sh
@@ -50,7 +50,7 @@ echo "🔧 Creating Cloudflare tunnel..."
 cloudflared tunnel create ${TUNNEL_NAME}
 
 # Get tunnel ID
-TUNNEL_ID=$(cloudflared tunnel list --name ${TUNNEL_NAME} --format json | jq -r '.[0].id')
+TUNNEL_ID=$(cloudflared tunnel list --name ${TUNNEL_NAME} --output json | jq -r '.[0].id')
 
 echo "📋 Tunnel ID: ${TUNNEL_ID}"
 


### PR DESCRIPTION
Giving --output option instead of --format allows a proper execution, at least using version 2026.1.2 (built 2026-01-23T12:45:53Z)

Fixes issue #4 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed tunnel configuration retrieval command to correctly produce output in the expected format.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->